### PR TITLE
Add firefox-delta chart to compare Firefox BiDi to Firefox CDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data.json
 firefox-delta.json
+firefox-delta-count.json
 firefox-failing.json
 chrome-failing.json
 dist

--- a/firefox-delta.mjs
+++ b/firefox-delta.mjs
@@ -10,7 +10,76 @@ function getParts(file) {
 }
 
 const files = readdirSync('./data');
-const firefoxLatest = files
+const data = files
+  .filter(
+    (file) =>
+      file.endsWith('.json') &&
+      file.includes('firefox') &&
+      !file.includes('cdp')
+  )
+  .sort()
+  .map((file, index) => {
+    const [browser, timestamp] = getParts(file);
+    const cdpFile = `./data/${browser}-cdp-${timestamp}.json`;
+    if (!existsSync(cdpFile)) {
+      return null;
+    }
+
+    const cdpPassBiDiFailTest = [];
+    const cdpFailBiDiPassTest = [];
+
+    const biDiTests = JSON.parse(
+      readFileSync(`./data/${browser}-${timestamp}.json`, 'utf-8')
+    ).tests;
+    const passingBiDiTests = new Set(
+      JSON.parse(
+        readFileSync(`./data/${browser}-${timestamp}.json`, 'utf-8')
+      ).passes.map((p) => p.fullTitle)
+    );
+    const passingCdpTests = new Set(
+      JSON.parse(readFileSync(cdpFile, 'utf-8')).passes.map((p) => p.fullTitle)
+    );
+
+    for (const test of biDiTests) {
+      if (
+        passingCdpTests.has(test.fullTitle) &&
+        !passingBiDiTests.has(test.fullTitle)
+      ) {
+        cdpPassBiDiFailTest.push(test.fullTitle);
+      }
+      if (
+        !passingCdpTests.has(test.fullTitle) &&
+        passingBiDiTests.has(test.fullTitle)
+      ) {
+        cdpFailBiDiPassTest.push(test.fullTitle);
+      }
+    }
+
+    return {
+      failing: cdpPassBiDiFailTest.length,
+      failingTests: cdpPassBiDiFailTest,
+      passing: cdpFailBiDiPassTest.length,
+      date: Number(timestamp) * 1000,
+      passingTests: cdpFailBiDiPassTest,
+    };
+  })
+  .filter((item) => item !== null);
+
+// Keep only the failing and passing counts to support the firefox delta chart.
+const countData = data.map((item) => {
+  return {
+    failing: item.failing,
+    passing: item.passing,
+    date: item.date,
+  };
+});
+writeFileSync('firefox-delta-count.json', JSON.stringify(countData, null, 2));
+
+// Write the latest run data to firefox-delta.json, including the full list
+// of passing vs failing tests.
+writeFileSync('firefox-delta.json', JSON.stringify(data.at(-1), null, 2));
+
+const latestFirefox = files
   .filter(
     (file) =>
       file.endsWith('.json') &&
@@ -19,46 +88,35 @@ const firefoxLatest = files
   )
   .sort()
   .at(-1);
-const [browser, timestamp] = getParts(firefoxLatest);
-const cdpFile = `./data/${browser}-cdp-${timestamp}.json`;
-if (!existsSync(cdpFile)) {
-  process.exit(0);
-}
 
-const cdpPassBiDiFailTest = [];
-const cdpFailBiDiPassTest = [];
+const timestamp = getParts(latestFirefox)[1];
+const latestFirefoxTests = JSON.parse(
+  readFileSync(`./data/firefox-${timestamp}.json`, 'utf-8')
+);
+const latestChromeTests = JSON.parse(
+  readFileSync(`./data/chrome-${timestamp}.json`, 'utf-8')
+);
 
-const biDiTests = JSON.parse(readFileSync(`./data/${browser}-${timestamp}.json`, 'utf-8')).tests;
-const passingBiDiTests = new Set(JSON.parse(readFileSync(`./data/${browser}-${timestamp}.json`, 'utf-8')).passes.map(p => p.fullTitle));
-const passingCdpTests = new Set(JSON.parse(readFileSync(cdpFile, 'utf-8')).passes.map(p => p.fullTitle));
+writeFileSync(
+  'firefox-failing.json',
+  JSON.stringify(
+    {
+      failing: latestFirefoxTests.failures.map((t) => t.fullTitle),
+      pending: latestFirefoxTests.pending.map((t) => t.fullTitle),
+    },
+    null,
+    2
+  )
+);
 
-for (const test of biDiTests) {
-  if (passingCdpTests.has(test.fullTitle) && !passingBiDiTests.has(test.fullTitle)) {
-    cdpPassBiDiFailTest.push(test.fullTitle);
-  }
-  if (!passingCdpTests.has(test.fullTitle) && passingBiDiTests.has(test.fullTitle)) {
-    cdpFailBiDiPassTest.push(test.fullTitle);
-  }
-}
-
-const firefoxDelta = {
-  failing: cdpPassBiDiFailTest.length,
-  failingTests: cdpPassBiDiFailTest,
-  passing: cdpFailBiDiPassTest.length,
-  passingTests: cdpFailBiDiPassTest
-};
-
-writeFileSync('firefox-delta.json', JSON.stringify(firefoxDelta, null, 2));
-
-const latestFirefoxTests = JSON.parse(readFileSync(`./data/firefox-${timestamp}.json`, 'utf-8'));
-const latestChromeTests = JSON.parse(readFileSync(`./data/chrome-${timestamp}.json`, 'utf-8'));
-
-writeFileSync('firefox-failing.json', JSON.stringify({
-  failing: latestFirefoxTests.failures.map(t => t.fullTitle),
-  pending: latestFirefoxTests.pending.map(t => t.fullTitle),
-}, null, 2));
-
-writeFileSync('chrome-failing.json', JSON.stringify({
-  failing: latestChromeTests.failures.map(t => t.fullTitle),
-  pending: latestChromeTests.pending.map(t => t.fullTitle),
-}, null, 2));
+writeFileSync(
+  'chrome-failing.json',
+  JSON.stringify(
+    {
+      failing: latestChromeTests.failures.map((t) => t.fullTitle),
+      pending: latestChromeTests.pending.map((t) => t.fullTitle),
+    },
+    null,
+    2
+  )
+);

--- a/main.mjs
+++ b/main.mjs
@@ -26,12 +26,15 @@ function buildTooltip(label, counts) {
   `;
 }
 
-async function main() {
-  const response = await fetch('./data.json');
-  const entries = await response.json();
+/**
+ * Sort chart data entries by date, ascending.
+ */
+function sortChartEntries(entries) {
   const chartData = [];
   let prev = [];
-  const offset = new Date(new Date().getTime() - (24 * 60 * 60 * 1000) * 90); // 90 days ago
+  const offset = new Date(new Date().getTime() - 24 * 60 * 60 * 1000 * 90); // 90 days ago
+
+  const index = 0;
   for (const entry of entries.reverse()) {
     const { date, firefoxCounts, chromeCounts } = entry;
     if (prev[0] === chromeCounts.passing && prev[1] === firefoxCounts.passing) {
@@ -51,6 +54,13 @@ async function main() {
   }
 
   chartData.reverse();
+  return chartData;
+}
+
+async function createMainChart() {
+  const response = await fetch('./data.json');
+  const entries = await response.json();
+  const chartData = sortChartEntries(entries);
 
   const ctx = document.getElementById('chart');
 
@@ -150,18 +160,86 @@ async function main() {
       },
     },
   });
+}
+
+async function createFirefoxDeltaChart() {
+  const response = await fetch('./firefox-delta-count.json');
+  const entries = await response.json();
+  const chartData = sortChartEntries(entries);
+
+  const canvas = document.createElement('canvas');
+  const ctx = document.getElementById('chart');
+
+  if (window.innerWidth > 2000) {
+    Chart.defaults.font.size = 38;
+  }
+
+  const datasets = [
+    {
+      label: 'Tests failing with Firefox BiDi but passing with Firefox CDP',
+      shortLabel: 'Tests failing',
+      data: chartData.map((item) => item[1]),
+      borderWidth: 1,
+    },
+  ];
+
+  if (window.location.search.includes('firefox-delta-all')) {
+    // Optionally show the new tests passing with BiDi but not with CDP
+    datasets.push({
+      label: 'Tests passing with Firefox BiDi but failing with Firefox CDP',
+      shortLabel: 'Tests passing',
+      data: chartData.map((item) => item[2]),
+      borderWidth: 1,
+    });
+  }
+
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: chartData.map((item) => formatDate(item[0])),
+      datasets,
+    },
+    options: {
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (context) =>
+              context.dataset.shortLabel + ': ' + context.parsed.y,
+          },
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          min: 0,
+        },
+      },
+    },
+  });
+}
+
+async function main() {
+  // Add ?firefox-delta to the URL to see data focused on Firefox BiDi vs
+  // Firefox CDP.
+  if (window.location.search.includes('firefox-delta')) {
+    await createFirefoxDeltaChart();
+  } else {
+    await createMainChart();
+  }
 
   const timeEl = document.querySelector('time');
   const date = formatDate(new Date());
   timeEl.textContent = date;
 
-  document.querySelector('#delta').textContent = (await fetch('./firefox-delta.json')
-    .then((res) => res.json())
-    .catch(() => {
-      return {
-        failing: 'X',
-      }
-    })).failing;
+  document.querySelector('#delta').textContent = (
+    await fetch('./firefox-delta.json')
+      .then((res) => res.json())
+      .catch(() => {
+        return {
+          failing: 'X',
+        };
+      })
+  ).failing;
 
   const firefoxFailing = await fetch('./firefox-failing.json')
     .then((res) => res.json())
@@ -169,9 +247,10 @@ async function main() {
       return {
         failing: [],
         pending: [],
-      }
-    })
-  document.querySelector('#firefox-failing').textContent = firefoxFailing.failing.length + firefoxFailing.pending.length;
+      };
+    });
+  document.querySelector('#firefox-failing').textContent =
+    firefoxFailing.failing.length + firefoxFailing.pending.length;
 
   const chromeFailing = await fetch('./chrome-failing.json')
     .then((res) => res.json())
@@ -180,8 +259,9 @@ async function main() {
         failing: [],
         pending: [],
       };
-    })
-  document.querySelector('#chrome-failing').textContent = chromeFailing.failing.length + chromeFailing.pending.length;
+    });
+  document.querySelector('#chrome-failing').textContent =
+    chromeFailing.failing.length + chromeFailing.pending.length;
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "data": "node preprocess-data.mjs && node firefox-delta.mjs",
-    "build": "rm -rf dist && mkdir -p dist && npm run data && node build.mjs && cp data.json dist/ && cp firefox-delta.json dist/ && cp firefox-failing.json dist/ && cp chrome-failing.json dist/ && cp index.html dist/ && cp main.mjs dist/",
+    "build": "rm -rf dist && mkdir -p dist && npm run data && node build.mjs && cp data.json dist/ && cp firefox-delta.json dist/ && cp firefox-delta-count.json dist/ && cp firefox-failing.json dist/ && cp chrome-failing.json dist/ && cp index.html dist/ && cp main.mjs dist/",
     "start": "http-server --port 9001 .",
     "prettier": "prettier --write ."
   },


### PR DESCRIPTION
Apart from some unexpected prettier changes, this is adding a new json file with the historical data for firefox delta as well as two endpoints:
- https://puppeteer.github.io/ispuppeteerwebdriverbidiready/?firefox-delta
- https://puppeteer.github.io/ispuppeteerwebdriverbidiready/?firefox-delta-all

Which display some Firefox specific data (BiDi vs CDP failing/passing). I tried to keep this as simple as possible, but let me know if you prefer something more elaborate.