### PR TITLE
fix: ignore test in delta that we don't track

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -256,7 +256,11 @@ async function main() {
   timeEl.textContent = date;
 
   document.querySelector('#delta').textContent = (
-    await fetch('./firefox-delta.json')
+    await fetch(
+      searchParams.has('all')
+        ? './firefox-delta-all.json'
+        : './firefox-delta.json',
+    )
       .then((res) => res.json())
       .catch(() => {
         return {


### PR DESCRIPTION
We currently don't ignore the test that we mark as ignored on the main page,
with this we have only 23 failing test that need action. 
(Plus 2 more will be fixed on main soon)

The correct number for all is also diplayed via the `all=true` query.

Current list
```json
{
  "failing": 23,
  "failingTests": [
    "Browser specs Browser.process should not return child_process for remote browser",
    "BrowserContext should isolate localStorage and cookies",
    "BrowserContext should provide a context id",
    "Page.click should click the button with deviceScaleFactor set",
    "Cookie specs Page.setCookie should default to setting secure cookie for HTTPS websites",
    "Cookie specs Page.setCookie should set secure same-site cookies from a frame",
    "Emulation Page.viewport should update media queries when resoltion changes",
    "Emulation Page.viewport should load correct pictures when emulation dpr",
    "Emulation Page.emulate should work",
    "Fixtures should close the browser when the node process closes",
    "Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
    "Launcher specs Puppeteer Browser.disconnect should reject waitForSelector when browser closes",
    "Launcher specs Puppeteer Browser.close should terminate network waiters",
    "navigation Page.goto should work when page calls history API in beforeunload",
    "network Request.postData should be |undefined| when there is no post data",
    "network Network Events Page.Events.Request",
    "network Network Events Page.Events.Response",
    "network Page.setExtraHTTPHeaders should throw for non-string header values",
    "Page Page.Events.Console should work for different console API calls with timing functions",
    "Page Page.setUserAgent should work",
    "Page Page.setUserAgent should work for subframes",
    "Page Page.setUserAgent should emulate device user-agent",
    "waittask specs Frame.waitForSelector should survive cross-process navigation"
  ]
}
```
  CC @whimboo 