### PR TITLE
chore: remove test

### DIFF
--- a/ignored-tests.json
+++ b/ignored-tests.json
@@ -127,6 +127,7 @@
   "network Request.headers should define Chrome as user agent header",
   "network Request.postData should work with blobs",
   "network Request.postData should work",
+  "network Request.postData should be |undefined| when there is no post data",
   "network Response.buffer should throw if the response does not have a body",
   "network Response.buffer should work with compression",
   "network Response.buffer should work",


### PR DESCRIPTION
`Request.postData` is not in the Spec and other test are already disabled.