### PR TITLE
chore: ignore test that does 2 connections

### DIFF
--- a/ignored-tests.json
+++ b/ignored-tests.json
@@ -113,6 +113,7 @@
   "JSHandle Page.evaluateHandle should return the RemoteObject",
   "Launcher specs Browser.Events.disconnected should be emitted when: browser gets closed, disconnected or underlying websocket gets closed",
   "Launcher specs Puppeteer Browser.close should terminate network waiters",
+  "Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
   "Launcher specs Puppeteer Browser.disconnect should reject waitForSelector when browser closes",
   "Launcher specs Puppeteer Puppeteer.connect should be able to close remote browser",
   "Launcher specs Puppeteer Puppeteer.connect should be able to connect multiple times to the same browser",


### PR DESCRIPTION
We already mark the test `Launcher specs Puppeteer Browser.disconnect should reject waitForSelector when browser closes` this is the same test only for navigation. I am confident both work but we can't have multiple connections to Firefox.