### PR TITLE
Ignore the initiator step test

### DIFF
--- a/ignored-tests.json
+++ b/ignored-tests.json
@@ -146,6 +146,7 @@
   "navigation Page.goto should send referer",
   "network Page.setBypassServiceWorker bypass for network",
   "network Request.headers should define Chrome as user agent header",
+  "network Request.initiator should return the initiator",
   "network Request.postData should be |undefined| when there is no post data",
   "network Request.postData should work with blobs",
   "network Request.postData should work",


### PR DESCRIPTION
I suggest we ignore the initiator feature for the next milestone. My investigation on the spec showed that it would be difficult to support it cross-browser and perhaps we should address it later. cc @Lightning00Blade @whimboo 