### PR TITLE
fix: explicitly add `permissions` to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,21 @@
 name: Build and deploy
+
+permissions:
+  actions: write
+  attestations: none
+  checks: write
+  contents: write
+  deployments: none
+  id-token: write
+  issues: none
+  discussions: none
+  packages: none
+  pages: write
+  pull-requests: none
+  repository-projects: write
+  security-events: none
+  statuses: none
+
 on:
   push:
     branches:


### PR DESCRIPTION
This should fix the recent failures: https://github.com/puppeteer/ispuppeteerwebdriverbidiready/actions/workflows/main.yml