### PR TITLE
feat: cleanup CDP delta dashboard

### DIFF
--- a/firefox-delta.mjs
+++ b/firefox-delta.mjs
@@ -70,20 +70,6 @@ const data = files
   })
   .filter((item) => item !== null);
 
-// Keep only the failing and passing counts to support the firefox delta chart.
-const countData = data.map((item) => {
-  return {
-    failing: item.failing,
-    passing: item.passing,
-    date: item.date,
-  };
-});
-writeFileSync('firefox-delta-count.json', JSON.stringify(countData, null, 2));
-
-// Write the latest run data to firefox-delta.json, including the full list
-// of passing vs failing tests.
-writeFileSync('firefox-delta-all.json', JSON.stringify(data.at(-1), null, 2));
-
 const { failingTests, passingTests, date } = data.at(-1);
 const filteredFailingTests = failingTests.filter(
   (test) => !ignoredTests.has(test),

--- a/index.html
+++ b/index.html
@@ -64,14 +64,6 @@
           Firefox (WebDriver BiDi) has
           <a
             class="json-link"
-            data-name="firefox-delta"
-            href="https://puppeteer.github.io/ispuppeteerwebdriverbidiready/firefox-delta.json"
-            ><span id="delta"></span> failing or skipped tests</a
-          >
-          that pass with Firefox (CDP). <br />
-          In total, Firefox (WebDriver BiDi) has
-          <a
-            class="json-link"
             data-name="firefox-failing"
             href="https://puppeteer.github.io/ispuppeteerwebdriverbidiready/firefox-failing.json"
             ><span id="firefox-failing"></span> failing or skipped tests</a

--- a/main.mjs
+++ b/main.mjs
@@ -168,84 +168,10 @@ async function createMainChart(showAllTests = false) {
   });
 }
 
-async function createFirefoxDeltaChart() {
-  const response = await fetch('./firefox-delta-count.json');
-  const entries = await response.json();
-
-  const chartData = [];
-
-  for (const entry of entries.reverse()) {
-    if (!entry) {
-      continue;
-    }
-    const { date, failing, passing } = entry;
-    chartData.push([new Date(date), failing, passing]);
-    if (new Date(date) < startDate) {
-      break;
-    }
-  }
-
-  chartData.reverse();
-
-  const ctx = document.getElementById('chart');
-
-  if (window.innerWidth > 2000) {
-    Chart.defaults.font.size = 38;
-  }
-
-  const datasets = [
-    {
-      label: 'Tests failing with Firefox BiDi but passing with Firefox CDP',
-      shortLabel: 'Tests failing',
-      data: chartData.map((item) => item[1]),
-      borderWidth: 1,
-    },
-  ];
-
-  if (searchParams.has('firefox-delta-all')) {
-    // Optionally show the new tests passing with BiDi but not with CDP
-    datasets.push({
-      label: 'Tests passing with Firefox BiDi but failing with Firefox CDP',
-      shortLabel: 'Tests passing',
-      data: chartData.map((item) => item[2]),
-      borderWidth: 1,
-    });
-  }
-
-  new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: chartData.map((item) => formatDate(item[0])),
-      datasets,
-    },
-    options: {
-      plugins: {
-        tooltip: {
-          callbacks: {
-            label: (context) =>
-              context.dataset.shortLabel + ': ' + context.parsed.y,
-          },
-        },
-      },
-      scales: {
-        y: {
-          beginAtZero: true,
-          min: 0,
-        },
-      },
-    },
-  });
-}
-
 async function main() {
   const allTests = searchParams.has('all');
-  // Add ?firefox-delta to the URL to see data focused on Firefox BiDi vs
-  // Firefox CDP.
-  if (searchParams.has('firefox-delta')) {
-    await createFirefoxDeltaChart();
-  } else {
-    await createMainChart(allTests);
-  }
+
+  await createMainChart(allTests);
 
   for (const link of document.querySelectorAll('.json-link')) {
     let filename = link.dataset.name;
@@ -263,16 +189,6 @@ async function main() {
   const timeEl = document.querySelector('time');
   const date = formatDate(new Date());
   timeEl.textContent = date;
-
-  document.querySelector('#delta').textContent = (
-    await fetch(allTests ? './firefox-delta-all.json' : './firefox-delta.json')
-      .then((res) => res.json())
-      .catch(() => {
-        return {
-          failing: 'X',
-        };
-      })
-  ).failing;
 
   const firefoxFailing = await fetch(
     allTests ? './firefox-failing-all.json' : './firefox-failing.json',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "data": "node preprocess-data.mjs && node firefox-delta.mjs",
-    "build": "rm -rf dist && mkdir -p dist && npm run data && node build.mjs && cp data*.json dist/ && cp firefox-delta*.json dist/ && cp firefox-delta-count*.json dist/ && cp firefox-failing*.json dist/ && cp chrome-failing*.json dist/ && cp index.html dist/ && cp main.mjs dist/ && cp ignored-tests.json dist/",
+    "build": "rm -rf dist && mkdir -p dist && npm run data && node build.mjs && cp data*.json dist/ && cp firefox-failing*.json dist/ && cp chrome-failing*.json dist/ && cp index.html dist/ && cp main.mjs dist/ && cp ignored-tests.json dist/",
     "start": "http-server --port 9001 .",
     "prettier": "prettier --write ."
   },

--- a/server.mjs
+++ b/server.mjs
@@ -20,11 +20,6 @@ const server = createServer((req, res) => {
       res.end(readFileSync('./data.json'));
       break;
     }
-    case '/firefox-delta.json': {
-      res.writeHead(200, { 'Content-Type': 'application/json;charset=utf-8' });
-      res.end(readFileSync('./firefox-delta.json'));
-      break;
-    }
     case '/firefox-failing.json': {
       res.writeHead(200, { 'Content-Type': 'application/json;charset=utf-8' });
       res.end(readFileSync('./firefox-failing.json'));


### PR DESCRIPTION
This PR removes the comparison between CDP and WebDriver BiDi for Firefox because Puppeteer no longer supports running CDP.