### PR TITLE
feat: extend data with chrome-bidi-only numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ firefox-delta*.json
 firefox-delta-count.json
 firefox-failing*.json
 chrome-failing*.json
+chromeBidiOnly-failing*.json
 dist
 
 # Installed npm modules

--- a/firefox-delta.mjs
+++ b/firefox-delta.mjs
@@ -97,13 +97,38 @@ const latestFirefox = files
   .sort()
   .at(-1);
 
+const defaultStats = {
+    "stats": {
+        "suites": 0,
+        "tests": 0,
+        "passes": 0,
+        "pending": 0,
+        "failures": 0,
+        "start": "never",
+        "end": "never",
+        "duration": 0
+    },
+    "tests": [],
+    "failures": [],
+    "passes": [],
+    "pending": []
+}
+
 const timestamp = getParts(latestFirefox)[1];
 const latestFirefoxTests = JSON.parse(
   readFileSync(`./data/firefox-${timestamp}.json`, 'utf-8'),
 );
-const latestChromeTests = JSON.parse(
-  readFileSync(`./data/chrome-${timestamp}.json`, 'utf-8'),
-);
+
+const chromeFilePath = `./data/chrome-${timestamp}.json`;
+const latestChromeTests = existsSync(chromeFilePath)
+  ? JSON.parse(readFileSync(chromeFilePath, 'utf-8'))
+  : defaultStats;
+
+const chromeBidiOnlyFilePath = `./data/chromeBidiOnly-${timestamp}.json`;
+const latestChromeBidiOnlyTests = existsSync(chromeBidiOnlyFilePath)
+  ? JSON.parse(readFileSync(chromeBidiOnlyFilePath, 'utf-8'))
+  : defaultStats;
+
 
 writeFileSync(
   'firefox-failing.json',
@@ -138,6 +163,22 @@ writeFileSync(
 );
 
 writeFileSync(
+  'chromeBidiOnly-failing.json',
+  JSON.stringify(
+    {
+      failing: latestChromeBidiOnlyTests.failures
+        .filter(filterIgnored)
+        .map((t) => t.fullTitle),
+      pending: latestChromeBidiOnlyTests.pending
+        .filter(filterIgnored)
+        .map((t) => t.fullTitle),
+    },
+    null,
+    2,
+  ),
+);
+
+writeFileSync(
   'firefox-failing-all.json',
   JSON.stringify(
     {
@@ -155,6 +196,17 @@ writeFileSync(
     {
       failing: latestChromeTests.failures.map((t) => t.fullTitle),
       pending: latestChromeTests.pending.map((t) => t.fullTitle),
+    },
+    null,
+    2,
+  ),
+);
+writeFileSync(
+  'chromeBidiOnly-failing-all.json',
+  JSON.stringify(
+    {
+      failing: latestChromeBidiOnlyTests.failures.map((t) => t.fullTitle),
+      pending: latestChromeBidiOnlyTests.pending.map((t) => t.fullTitle),
     },
     null,
     2,

--- a/get-test-results.sh
+++ b/get-test-results.sh
@@ -23,7 +23,12 @@ bidi-chrome() {
   npm run test -- --test-suite chrome-bidi --no-coverage --save-stats-to $CWD/data/chrome-$timestamp.json
 }
 
+bidi-only-chrome() {
+  npm run test -- --test-suite chrome-bidi-only --no-coverage --save-stats-to $CWD/data/chromeBidiOnly-$timestamp.json
+}
+
 bidi-firefox
 bidi-chrome
+bidi-only-chrome
 
 exit 0

--- a/index.html
+++ b/index.html
@@ -67,13 +67,20 @@
             data-name="firefox-failing"
             href="https://puppeteer.github.io/ispuppeteerwebdriverbidiready/firefox-failing.json"
             ><span id="firefox-failing"></span> failing or skipped tests</a
-          >
-          and Chrome (WebDriver BiDi) has
+          >,
+          Chrome (WebDriver BiDi) has
           <a
             class="json-link"
             data-name="chrome-failing"
             href="https://puppeteer.github.io/ispuppeteerwebdriverbidiready/chrome-failing.json"
             ><span id="chrome-failing"></span> failing or skipped tests</a
+          >
+          and Chrome (WebDriver BiDi only) has
+          <a
+            class="json-link"
+            data-name="chromeBidiOnly-failing"
+            href="https://puppeteer.github.io/ispuppeteerwebdriverbidiready/chromeBidiOnly-failing.json"
+            ><span id="chromeBidiOnly-failing"></span> failing or skipped tests</a
           >.
           <p id="ready">
             * Includes tests deemed necessary for production-ready use of

--- a/preprocess-data.mjs
+++ b/preprocess-data.mjs
@@ -70,6 +70,15 @@ function mapData(filter) {
         total: 0,
         unsupported: 0,
       },
+      chromeBidiOnlyCounts: groupByDate
+        .get(date)
+        .find((item) => item.browser === 'chromeBidiOnly')?.counts || {
+        passing: 0,
+        failing: 0,
+        skipping: 0,
+        total: 0,
+        unsupported: 0,
+      },
       firefoxCounts: groupByDate
         .get(date)
         .find((item) => item.browser === 'firefox')?.counts || {

--- a/server.mjs
+++ b/server.mjs
@@ -30,6 +30,11 @@ const server = createServer((req, res) => {
       res.end(readFileSync('./chrome-failing.json'));
       break;
     }
+    case '/chromeBidiOnly-failing.json': {
+      res.writeHead(200, { 'Content-Type': 'application/json;charset=utf-8' });
+      res.end(readFileSync('./chromeBidiOnly-failing.json'));
+      break;
+    }
   }
 });
 


### PR DESCRIPTION
Add Chrome BiDi only passing rate metric. Based on https://github.com/puppeteer/puppeteer/pull/14267.

Tested locally.